### PR TITLE
Add algorithm header to cube.cpp

### DIFF
--- a/timecube/cube.cpp
+++ b/timecube/cube.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cctype>
 #include <cerrno>
 #include <charconv>


### PR DESCRIPTION
Fixes compilation with GCC.

```
timecube/cube.cpp: In member function ‘void timecube::{anonymous}::ReadLineStringView::operator()(char*)’:
timecube/cube.cpp:62:30: error: ‘copy_n’ is not a member of ‘std’; did you mean ‘copy’?
   62 |                         std::copy_n(sv.begin(), len, buf);
      |                              ^~~~~~
      |                              copy
```